### PR TITLE
fix(deps): add Python 3.10 on Ubuntu 24 LTS

### DIFF
--- a/src/components/YCSetup4.vue
+++ b/src/components/YCSetup4.vue
@@ -7,7 +7,7 @@
         <li>On your <b>Primary</b> laptop click on the <b>9 Dots</b> in the bottom left corner of your Ubuntu desktop and then click <b>Terminal</b>.</li>
         <li>Click <b>Copy</b> to copy the text below this line.</li>
         <div style="width:75%;" class="input-group mb-3 mt-3">
-        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && sudo apt-get install python3.10 && sudo apt-get install -y python3-pip python3.10-venv git && python3 -m venv ~/my_venv && source ~/my_venv/bin/activate && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelThreePrimary">
+        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && { grep -q "^VERSION=\"24.04" /etc/os-release && sudo apt-add-repository -y ppa:deadsnakes/ppa || true; } && sudo apt-get install -y python3.10 && sudo apt-get install -y python3.10-venv git && python3.10 -m venv ~/my_venv && source ~/my_venv/bin/activate && python -m ensurepip --upgrade && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelThreePrimary">
           <div class="input-group-append">
             <span v-on:click="copy1" class="btn btn-secondary" id="basic-addon2">Copy</span>
           </div>

--- a/src/components/YCSetup6.vue
+++ b/src/components/YCSetup6.vue
@@ -7,7 +7,7 @@
         <li>On your <b>Secondary</b> laptop click on the <b>9 Dots</b> in the bottom left corner of your Ubuntu desktop and then click <b>Terminal</b>.</li>
         <li>Click <b>Copy</b> to copy the text below this line.</li>
         <div style="width:75%;" class="input-group mb-3 mt-3">
-        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && sudo apt-get install python3.10 && sudo apt-get install -y python3-pip python3.10-venv git && python3 -m venv ~/my_venv && source ~/my_venv/bin/activate && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelThreeSecondaryCreate">
+        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && { grep -q "^VERSION=\"24.04" /etc/os-release && sudo apt-add-repository -y ppa:deadsnakes/ppa || true; } && sudo apt-get install -y python3.10 && sudo apt-get install -y python3.10-venv git && python3.10 -m venv ~/my_venv && source ~/my_venv/bin/activate && python -m ensurepip --upgrade && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelThreeSecondaryCreate">
           <div class="input-group-append">
             <span v-on:click="copy1" class="btn btn-secondary" id="basic-addon2">Copy</span>
           </div>

--- a/src/components/YCSetup6R.vue
+++ b/src/components/YCSetup6R.vue
@@ -7,7 +7,7 @@
         <li>On your <b>Secondary</b> laptop click on the <b>9 Dots</b> in the bottom left corner of your Ubuntu desktop and then click <b>Terminal</b>.</li>
         <li>Click <b>Copy</b> to copy the text below this line.</li>
         <div style="width:75%;" class="input-group mb-3 mt-3">
-        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && sudo apt-get install python3.10 && sudo apt-get install -y python3-pip python3.10-venv git && python3 -m venv ~/my_venv && source ~/my_venv/bin/activate && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelThreeSecondaryRecover">
+        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && { grep -q "^VERSION=\"24.04" /etc/os-release && sudo apt-add-repository -y ppa:deadsnakes/ppa || true; } && sudo apt-get install -y python3.10 && sudo apt-get install -y python3.10-venv git && python3.10 -m venv ~/my_venv && source ~/my_venv/bin/activate && python -m ensurepip --upgrade && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelThreeSecondaryRecover">
           <div class="input-group-append">
             <span v-on:click="copy1" class="btn btn-secondary" id="basic-addon2">Copy</span>
           </div>

--- a/src/components/YHSetup4.vue
+++ b/src/components/YHSetup4.vue
@@ -7,7 +7,7 @@
         <li>On your laptop click on the <b>9 Dots</b> in the bottom left corner of your Ubuntu desktop and then click <b>Terminal</b>.</li>
         <li>Click <b>Copy</b> to copy the text below this line.</li>
         <div style="width:75%;" class="input-group mb-3 mt-3">
-        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && sudo apt-get install python3.10 && sudo apt-get install -y python3-pip python3.10-venv git && python3 -m venv ~/my_venv && source ~/my_venv/bin/activate && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelOne">
+        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && { grep -q "^VERSION=\"24.04" /etc/os-release && sudo apt-add-repository -y ppa:deadsnakes/ppa || true; } && sudo apt-get install -y python3.10 && sudo apt-get install -y python3.10-venv git && python3.10 -m venv ~/my_venv && source ~/my_venv/bin/activate && python -m ensurepip --upgrade && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelOne">
           <div class="input-group-append">
             <span v-on:click="copy1" class="btn btn-secondary" id="basic-addon2">Copy</span>
           </div>

--- a/src/components/YWSetup4.vue
+++ b/src/components/YWSetup4.vue
@@ -7,7 +7,7 @@
         <li>On your laptop click on the <b>9 Dots</b> in the bottom left corner of your Ubuntu desktop and then click <b>Terminal</b>.</li>
         <li>Click <b>Copy</b> to copy the text below this line.</li>
         <div style="width:75%;" class="input-group mb-3 mt-3">
-        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && sudo apt-get install python3.10 && sudo apt-get install -y python3-pip python3.10-venv git && python3 -m venv ~/my_venv && source ~/my_venv/bin/activate && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelTwo">
+        <input v-on:click="copy1" v-b-tooltip.click v-b-tooltip.blur title="Copied" readonly type="text" class="form-control" aria-label="Default" id="copy1" aria-describedby="inputGroup-sizing-default" value="sudo apt update && sudo apt-get upgrade -y && { grep -q "^VERSION=\"24.04" /etc/os-release && sudo apt-add-repository -y ppa:deadsnakes/ppa || true; } && sudo apt-get install -y python3.10 && sudo apt-get install -y python3.10-venv git && python3.10 -m venv ~/my_venv && source ~/my_venv/bin/activate && python -m ensurepip --upgrade && git clone https://github.com/jwweatherman/yeticold.git ~/yeticold; pip install flask; pip install bip32; python3 ~/yeticold/initialize.py YetiLevelTwo">
           <div class="input-group-append">
             <span v-on:click="copy1" class="btn btn-secondary" id="basic-addon2">Copy</span>
           </div>


### PR DESCRIPTION
Closes #52.

This PR fixes the one-liner command to work on Ubuntu 24.

The current command installs python3.10, which is not available in the default apt package repos in Ubuntu 24.

The approach taken here is to:
1. If the OS version starts with 24.04, add the deadsnakes repo
2. Assume yes when installing python3.10 via apt
3. Remove the command to install pip via apt
4. Install pip via the ensurepip module inside `my_venv`.
